### PR TITLE
Calendar title keeps fixed width now

### DIFF
--- a/react/src/App.css
+++ b/react/src/App.css
@@ -225,6 +225,7 @@ body {
   font-size: 3rem;
   font-weight: normal;
   color: var(--color-font-light);
+  width: 12rem;
 }
 
 .month__button {


### PR DESCRIPTION
Made calendar title keep fixed size to enchance user experience, buttons are no longer changing places depending on month name length.