### PR TITLE
Calendar title keeps fixed width now

### DIFF
--- a/react/src/components/other/Title/Title.scss
+++ b/react/src/components/other/Title/Title.scss
@@ -5,4 +5,5 @@
   align-items: center;
   justify-content: center;
   margin: auto;
+  width: 12rem;
 }


### PR DESCRIPTION
Made calendar title keep fixed size to enchance user experience, buttons are no longer changing places depending on month name length.